### PR TITLE
Add arc browser to the list of valid browsers.

### DIFF
--- a/internal/jsonapi/manifest/setup_test.go
+++ b/internal/jsonapi/manifest/setup_test.go
@@ -50,7 +50,7 @@ func TestValidBrowser(t *testing.T) {
 func TestValidBrowsers(t *testing.T) {
 	t.Parallel()
 
-	validBrowsers := []string{"brave", "chrome", "chromium", "firefox", "iridium", "slimjet", "vivaldi"}
+	validBrowsers := []string{"arc", "brave", "chrome", "chromium", "firefox", "iridium", "slimjet", "vivaldi"}
 	if runtime.GOOS == "windows" {
 		validBrowsers = []string{"chrome", "chromium", "firefox"}
 	}


### PR DESCRIPTION
This PR should solve the `Build gopass-jsonapi / mac` workflow by adding the browser `arc` to the list of valid browsers under `setup_test.go`.